### PR TITLE
Attempts to parse cfnex tag contents as JSON object

### DIFF
--- a/extensions/include-file.js
+++ b/extensions/include-file.js
@@ -5,8 +5,12 @@ const { readFile } = require('../lib/utils')
 function replaceSubs(str) {
 	if (str.indexOf('<%cfnex') !== -1 && str.indexOf('cfnex%>') !== -1) {
 		const left = str.split('<%cfnex')[0]
-		const middle = str.split('<%cfnex')[1].split('cfnex%>')[0]
+		let middle = str.split('<%cfnex')[1].split('cfnex%>')[0]
 		const right = str.split('cfnex%>')[1]
+
+		try {
+			middle = JSON.parse(middle)
+		} catch (e) { /* if the parse fails, it will leave the original string intact */ }
 
 		return { 'Fn::Join': ['', [left, middle, right]] }
 	}

--- a/test/e2e/expected.json
+++ b/test/e2e/expected.json
@@ -734,7 +734,9 @@
                     "",
                     [
                       "echo ECS_CLUSTER=",
-                      " { \"Ref\": \"EcsCluster\" } ",
+                      {
+                        "Ref": "EcsCluster"
+                      },
                       "  >> /etc/ecs/ecs.config"
                     ]
                   ]


### PR DESCRIPTION
When encountering <%cfnex tags in the include-file extension, this now attempts to parse the contents of the tag as JSON so that the outer template can use object references, etc.

Implements fix for issue #23 